### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM tensorflow/tensorflow:1.15.5-py3
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && \
+    apt-get -qqq install --no-install-recommends git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt
+
+RUN git clone https://github.com/JiahuiYu/neuralgym.git /tmp/neuralgym && \
+    pip install --no-cache-dir /tmp/neuralgym && \
+    rm -rf /tmp/neuralgym && \
+    pip install --no-cache-dir opencv-python==4.9.0.80 Pillow numpy pyyaml
+
+RUN adduser nonroot
+USER nonroot
+COPY --chown=nonroot:nonroot ./ /repo
+WORKDIR /repo
+
+ENTRYPOINT ["/usr/bin/env", "python", "/repo/main.py"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ And also a shoutout to [Chu-Tak Li](https://chutakcode.wixsite.com/website) for 
 
 ## Run
 
+### Docker
+
+1. Clone this repository to your computer.
+2. From the repository root, build a Docker image with the command `docker build -t watermark-removal .`
+3. Download the model dir using this [link](https://drive.google.com/drive/folders/1xRV4EdjJuAfsX9pQme6XeoFznKXG0ptJ?usp=sharing).
+4. Create and run a docker container with the image you built using the command:
+```bash
+docker run --rm -v '<path_to_model_dir>:/repo/model' -v '<path_to_input_dir>:/input' -v '<path_to_output_dir>:/output' watermark-removal --checkpoint_dir /repo/model --image '/input/<input_image_file>' --output '/output/<output_image_file>' --watermark_type istock
+```
+
+### Google colab (broken)
+
 - use [Google colab](https://research.google.com/colaboratory/)
 
 - First of all, clone this repo


### PR DESCRIPTION
Adds a non-root Dockerfile and basic instructions on how to use it. This greatly simplifies managing the sometimes outdated or undocumented dependencies needed to run this project. 